### PR TITLE
endif got eaten from lines

### DIFF
--- a/Meleze.Web/Razor/MinifyHtmlCodeGenerator.cs
+++ b/Meleze.Web/Razor/MinifyHtmlCodeGenerator.cs
@@ -10,7 +10,7 @@ namespace Meleze.Web.Razor
     internal static class MinifyHtmlCodeGenerator
     {
         private static char[] _whiteSpaceSepartors = new char[] { '\n', '\r' };
-        private static string[] _commentsMarkers = new string[] { "{", "}", "function", "var", "[if" };
+        private static string[] _commentsMarkers = new string[] { "{", "}", "function", "var", "[if", "[endif" };
 
         public static string Minify(string content)
         {


### PR DESCRIPTION
like &lt;!--[if gt IE 8]&gt;&lt;!--&gt;&lt;html class=&quot;no-js&quot; lang=&quot;hu&quot;&gt;&lt;!--&lt;![endif]--&gt; which is a common design pattern.

for example this is from h5bp.com:

&lt;!--[if lt IE 7]&gt;&lt;html class=&quot;no-js ie6 oldie&quot; lang=&quot;hu&quot;&gt;&lt;![endif]--&gt;
&lt;!--[if IE 7]&gt;&lt;html class=&quot;no-js ie7 oldie&quot; lang=&quot;hu&quot;&gt;&lt;![endif]--&gt;
&lt;!--[if IE 8]&gt;&lt;html class=&quot;no-js ie8 oldie&quot; lang=&quot;hu&quot;&gt;&lt;![endif]--&gt;
&lt;!--[if gt IE 8]&gt;&lt;!--&gt;&lt;html class=&quot;no-js&quot; lang=&quot;hu&quot;&gt;&lt;!--&lt;![endif]--&gt;
